### PR TITLE
Refs #81768: Added checks to prevent creating additional indexes on _id field.

### DIFF
--- a/django_mongodb_engine/creation.py
+++ b/django_mongodb_engine/creation.py
@@ -126,8 +126,7 @@ class DatabaseCreation(NonrelDatabaseCreation):
             if not column == '_id':
                 if field.name in descending_indexes:
                     column = [(column, DESCENDING)]
-                    ensure_index(column, unique=field.unique,
-                         sparse=field.name in sparse_indexes)
+                ensure_index(column, unique=field.unique, sparse=field.name in sparse_indexes)
 
         def create_compound_indexes(indexes, **kwargs):
             # indexes: (field1, field2, ...).

--- a/django_mongodb_engine/creation.py
+++ b/django_mongodb_engine/creation.py
@@ -70,7 +70,8 @@ class DatabaseCreation(NonrelDatabaseCreation):
                 # field doesn't need an index.
                 continue
             column = '_id' if field.primary_key else field.column
-            ensure_index(column, unique=field.unique)
+            if not column == '_id':
+                ensure_index(column, unique=field.unique)
 
         # Django unique_together indexes.
         indexes = list(indexes)
@@ -122,9 +123,10 @@ class DatabaseCreation(NonrelDatabaseCreation):
                 # field doesn't need an index.
                 continue
             column = '_id' if field.primary_key else field.column
-            if field.name in descending_indexes:
-                column = [(column, DESCENDING)]
-            ensure_index(column, unique=field.unique,
+            if not column == '_id':
+                if field.name in descending_indexes:
+                    column = [(column, DESCENDING)]
+                    ensure_index(column, unique=field.unique,
                          sparse=field.name in sparse_indexes)
 
         def create_compound_indexes(indexes, **kwargs):


### PR DESCRIPTION
Index on _id field is created automatically when a collection is created. We do not need to recreate an index when it is already present.